### PR TITLE
removing incompatible -accel option

### DIFF
--- a/cleanroom/firestarter/qemutools.py
+++ b/cleanroom/firestarter/qemutools.py
@@ -179,8 +179,6 @@ def run_qemu(
         "cores={}".format(parse_result.cores),
         "-machine",
         "pc-q35-2.12",
-        "-accel",
-        "kvm",
         "-m",
         "size={}".format(parse_result.memory),  # memory
         "-object",


### PR DESCRIPTION
In a recent release of qemu the -accel and -machine options became incompatible. According to the [arch wiki](https://wiki.archlinux.org/index.php/QEMU#Enabling_KVM) -accel kvm is equivalent to -enable-kvm - which is already enabled. So I removed -accel kvm.