### PR TITLE
Add target_distribution to _parse_and_verify_string

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,7 +97,7 @@ def command_manager():
 # Injected into parser:
 def _parse_and_verify_string(parser, data, expected_base_system, expected):
     """Verify one line of input to the Parser."""
-    (base_system, exec_obj_list) = parser._parse_string(data, "<TEST_DATA>")
+    (base_system, target_distribution, exec_obj_list) = parser._parse_string(data, "<TEST_DATA>")
     result = list(
         map(
             lambda x: (x.command, x.args, x.kwargs, x.location.line_number),


### PR DESCRIPTION
196/659 tests fail on a clean checkout, likely because `conftest.py` wasn't updated to account for the `target_distribution` return value that was added to `cleanroom/command.py` in 0b9737c. Adding this value appears to fix this issue.

![original](https://user-images.githubusercontent.com/26632151/104788014-23427680-575f-11eb-90de-8ea6cf2ad7e7.png)
![patched](https://user-images.githubusercontent.com/26632151/104788017-23db0d00-575f-11eb-9967-aaff4db6ef4a.png)

